### PR TITLE
Set default orientation during intialisation

### DIFF
--- a/examples/esp32c6/src/bin/async_main.rs
+++ b/examples/esp32c6/src/bin/async_main.rs
@@ -12,7 +12,7 @@ use esp_hal::{
     spi::master::Spi,
     timer::{timg::TimerGroup, OneShotTimer},
 };
-use paa5100je_pmw3901::{MotionDelta, PixArtSensor};
+use paa5100je_pmw3901::{MotionDelta, PixArtSensor, RotationDegrees};
 use {defmt_rtt as _, esp_backtrace as _};
 
 #[esp_hal_embassy::main]
@@ -49,6 +49,8 @@ async fn main(spawner: Spawner) {
     let mut sensor = PixArtSensor::new_paa5100je(spi, &mut sensor_timer)
         .await
         .unwrap();
+
+    sensor.set_rotation(RotationDegrees::_0).await.unwrap();
 
     info!("Sensor ID: {:?}", sensor.id().await.unwrap());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,9 @@ impl<SPI: SpiDevice> PixArtSensor<SPI> {
         }
         debug!("Product ID: {}", id.product_id);
         debug!("Revision: {}", id.revision);
+
+        // The default settings do not conform to any orientation, so we set rotation to 0 here to provide a known default.
+        self.set_rotation(RotationDegrees::_0).await?;
         Ok(())
     }
 


### PR DESCRIPTION
# Description

The default settings of the sensor do not conform to any rotation. In order to make sure that the sensor starts in a known state, we set the rotation to 0 in the init function.

## Type of change

Please Tick the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with the example code, as well as on a project using this library as a dependency.

## Checklist

- [x] My code follows the style guidelines of this project (this should be caught by the CI)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (this should be caught by the CI)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
